### PR TITLE
Add link to v1 user manual

### DIFF
--- a/includes/html/sections/contact.pug
+++ b/includes/html/sections/contact.pug
@@ -6,5 +6,5 @@ section#contact
       a(href='mailto:philipp@magicshifter.net') email!
 
     p
-      | If you are looking for information about the MagicShifter V1 just 
-      a(href=`${WEB_ROOT}v1`) click here!
+      | If you are looking for the user manual of the MagicShifter V1 just 
+      a(href=`https://docs.google.com/document/d/1_cqh2J4C_Npqz5KXsosdRo691K8Sucw97ZeopUi3K8k/edit`) click here!


### PR DESCRIPTION
Found the old user manual via web.archive.org snapshots of magicshifter.net, the /v1/ link wasn't working.